### PR TITLE
Remove RumbleMod reference

### DIFF
--- a/FasterScroll/FasterScroll.csproj
+++ b/FasterScroll/FasterScroll.csproj
@@ -71,11 +71,6 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="RumbleMod">
-      <HintPath>$(BeatSaberDir)\Plugins\RumbleMod.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Data.dll</HintPath>

--- a/FasterScroll/FasterScrollController.cs
+++ b/FasterScroll/FasterScrollController.cs
@@ -5,7 +5,6 @@ using IPA.Utilities;
 using VRUIControls;
 using System.Linq;
 using Libraries.HM.HMLib.VR;
-using RumbleMod;
 
 #if DEBUG_FASTERSCROLL
 using System.Collections;


### PR DESCRIPTION
It doesn't seem to be referenced anymore as the code is commented out - this commit means we don't have to have RumbleMod referenced in order to build FasterScroll